### PR TITLE
fix quickstart: ensure original_signature is Signature

### DIFF
--- a/lib/desiru/module.rb
+++ b/lib/desiru/module.rb
@@ -15,15 +15,7 @@ module Desiru
     attr_reader :signature, :model, :config, :demos, :metadata
 
     def initialize(signature, model: nil, config: {}, demos: [], metadata: {})
-      @signature = case signature
-                   when Signature
-                     signature
-                   when String
-                     Signature.new(signature)
-                   else
-                     raise ModuleError, 'Signature must be a String or Signature instance'
-                   end
-
+      @signature = Signature.wrap(signature)
       @model = model || Desiru.configuration.default_model
       @config = default_config.merge(config)
       @demos = demos

--- a/lib/desiru/modules/chain_of_thought.rb
+++ b/lib/desiru/modules/chain_of_thought.rb
@@ -4,11 +4,13 @@ module Desiru
   module Modules
     # Chain of Thought module - adds reasoning steps before producing outputs
     class ChainOfThought < Predict
+      attr_reader :original_signature
+
       def initialize(signature, **)
         # Extend signature to include reasoning field
         extended_sig = extend_signature_with_reasoning(signature)
         super(extended_sig, **)
-        @original_signature = signature
+        @original_signature = Signature.wrap(signature)
       end
 
       protected

--- a/lib/desiru/signature.rb
+++ b/lib/desiru/signature.rb
@@ -76,6 +76,17 @@ module Desiru
     alias inputs input_fields
     alias outputs output_fields
 
+    def self.wrap(signature_string_or_instance)
+      case signature_string_or_instance
+      when Signature
+        signature_string_or_instance
+      when String
+        Signature.new(signature_string_or_instance)
+      else
+        raise ModuleError, 'Signature must be a String or Signature instance'
+      end
+    end
+
     def initialize(signature_string, descriptions: {})
       @raw_signature = signature_string
       @descriptions = descriptions

--- a/spec/desiru/modules/chain_of_thought_spec.rb
+++ b/spec/desiru/modules/chain_of_thought_spec.rb
@@ -1,0 +1,40 @@
+# frozen_string_literal: true
+
+require 'spec_helper'
+require 'desiru/modules/chain_of_thought'
+
+RSpec.describe Desiru::Modules::ChainOfThought do
+  let(:mock_model) do
+    double('Model',
+           complete: { content: <<~CNT },
+             reasoning: Some reason for this mock answer
+             answer: 42
+           CNT
+           temperature: 0.7,
+           respond_to?: true)
+  end
+
+  describe '#initialize' do
+    context 'with signature string' do
+      let(:signature_string) { 'question: string -> answer: string' }
+      let(:cot_module) { described_class.new(signature_string, model: mock_model) }
+
+      it 'wraps original_signature with Signature instance' do
+        expect(cot_module.original_signature).to respond_to(:output_fields)
+        expect(cot_module.original_signature).to be_a(Desiru::Signature)
+      end
+    end
+  end
+
+  describe "#forward" do
+    context 'with signature string' do
+      let(:signature_string) { 'question: string -> answer: string' }
+      let(:cot_module) { described_class.new(signature_string, model: mock_model) }
+
+      it 'can build the prompt and complete a response' do
+        result = cot_module.call(question: "Two dice are tossed. What is the probability that the sum equals two?")
+        expect(result.answer).to eq "42"
+      end
+    end
+  end
+end


### PR DESCRIPTION
Currently, the [quickstart example](https://github.com/obie/desiru?tab=readme-ov-file#quick-start) errors because the CoT `original_signature` remains a string rather than a `Signature` instance.

```
 result = cot.call(question: "Two dice are tossed. What is the probability that the sum equals two?")
[Desiru] 2025-06-26 11:07:40 -0700: WARN -- Retrying module execution (attempt 1/3)
[Desiru] 2025-06-26 11:07:41 -0700: WARN -- Retrying module execution (attempt 2/3)
[Desiru] 2025-06-26 11:07:42 -0700: WARN -- Retrying module execution (attempt 3/3)
[Desiru] 2025-06-26 11:07:43 -0700: ERROR -- Module execution failed: undefined method 'output_fields' for an instance of String
(ponds):2:in '<main>': Module execution failed: undefined method 'output_fields' for an instance of String (Desiru::ModuleError)
/Users/dimroc/.gem/ruby/3.4.2/bundler/gems/desiru-b5b302af0e3b/lib/desiru/modules/chain_of_thought.rb:26:in 'Desiru::Modules::ChainOfThought#build_system_prompt': undefined method 'output_fields' for an instance of String (NoMethodError)

          #{@original_signature.output_fields.keys.map { |field| "#{field}: Your #{field} here" }.join("\n")}
                               ^^^^^^^^^^^^^^
        from /Users/dimroc/.gem/ruby/3.4.2/bundler/gems/desiru-b5b302af0e3b/lib/desiru/modules/predict.rb:33:in 'Desiru::Modules::Predict#build_prompt'
        from /Users/dimroc/.gem/ruby/3.4.2/bundler/gems/desiru-b5b302af0e3b/lib/desiru/modules/predict.rb:15:in 'Desiru::Modules::Predict#forward'
        from /Users/dimroc/.gem/ruby/3.4.2/bundler/gems/desiru-b5b302af0e3b/lib/desiru/module.rb:50:in 'Desiru::Module#call'
        from /Users/dimroc/.gem/ruby/3.4.2/bundler/gems/desiru-b5b302af0e3b/lib/desiru/core/traceable.rb:20:in 'Desiru::Core::Traceable#call'
```

This PR ensures the `ChainOfThought#original_signature` becomes a Signature instance. To implement this, there were a few liberties taken:

1. DRY'd up the signature wrapping into `Signature.wrap`
1. Made `ChainOfThought#original_signature` a public attr_reader for easier access and testability, mimicing Module#signature.


### Testing details and red, green refactor

![Screenshot 2025-06-26 at 11 02 18 AM](https://github.com/user-attachments/assets/c998809c-39f5-461d-bbdf-fc2471790596)

Original error:

![Screenshot 2025-06-26 at 10 44 47 AM](https://github.com/user-attachments/assets/3cdc3990-8424-4e88-bb26-a2c7f76d81f7)

