### PR TITLE
Add support for specifying custom OpenAI uri base

### DIFF
--- a/lib/desiru/models/open_ai.rb
+++ b/lib/desiru/models/open_ai.rb
@@ -90,12 +90,11 @@ module Desiru
       private
 
       def fetch_models
-        puts(@client.uri_base)
         response = @client.models.list
 
         @models_cache = {}
         response['data'].each do |model|
-          # Filter for chat models only
+          # Filter for chat models only, if using official OpenAI endpoint
           if @client.uri_base == 'https://api.openai.com/'
             next unless model['id'].include?('gpt') || model['id'].include?('o1')
           end


### PR DESCRIPTION
This PR adds support for passing a custom endpoint to the OpenAI model class.

```ruby
Desiru::Models::OpenAI.new(api_key: ENV['OPENAI_API_KEY'], uri_base: "http://127.0.0.1:1234")
```

This allows for users to call OpenAI compatible endpoints (OpenRouter, TogetherAI, LM Studio).